### PR TITLE
DX-949 Add new governmentPayment tags and improve coverage

### DIFF
--- a/.github/workflows/Sync-rdme.yml
+++ b/.github/workflows/Sync-rdme.yml
@@ -27,9 +27,11 @@ jobs:
           rdme openapi validate ./reference/core.json
           rdme openapi validate ./reference/insights.json
           rdme openapi validate ./reference/analytics.json
+          rdme openapi validate ./reference/enrich.json
 
       - name: Upload API definitions
         run: |
           rdme openapi upload ./reference/core.json --slug=core --key=${{ secrets.README_API_KEY }}
           rdme openapi upload ./reference/insights.json --slug=insights --key=${{ secrets.README_API_KEY }}
           rdme openapi upload ./reference/analytics.json --slug=analytics --key=${{ secrets.README_API_KEY }}
+          rdme openapi upload ./reference/enrich.json --slug=enrich --key=${{ secrets.README_API_KEY }}

--- a/reference/enrich.json
+++ b/reference/enrich.json
@@ -1,1 +1,1205 @@
-{"openapi":"3.0.1","info":{"title":"Enrich","description":"All included utility endpoints for Basiq partners","version":"3.0.0","license":{"name":"Commercial","url":"https://basiq.io"}},"servers":[{"url":"https://au-api.basiq.io"}],"paths":{"/enrich":{"get":{"tags":["Enrich"],"summary":"Enrich","operationId":"Enrich","description":"The Enrich resource enables you to retrieve details by passing in a search query containing a bank transaction description. The service enriches transaction data with multiple attributes, returning a transaction classification and three metadata components. The transaction classification will first determine if the transaction is of type payment, transfer, cash-withdrawal, bank-fee etc. The engine then derives merchant information, purchase location and prescribes an industry standard categorisation for each payment transaction.","parameters":[{"name":"q","in":"query","description":"This is the search string that is used to lookup the entity (merchant) information.\n```**q=garfish%20MANLY%20NS**&country=AU&institution=AU06703```","schema":{"type":"string"},"required":true},{"name":"institution","in":"query","description":"Identifies the institution from where the transaction was derived. This must be a Basiq recognisable institution ID.\n```enrich?METRO%20PETROLEUM%20FR%20FORE&country=AU&accountType=transaction&amount=-12.95&**institution=AU04301**```","schema":{"type":"string"},"required":true},{"name":"country","in":"query","description":"Specifies the country the search should be narrowed down to. Passing in a country value will limit the search to the specified country. The country must be in ISO 3166 Alpha-2 format\n```q=garfish%20MANLY%20NS&**country=AU**&institution=AU06703```","schema":{"type":"string"},"required":true},{"name":"mcc","in":"query","description":"Merchant classification code as defined by Visa and Mastercard\n```q=garfish%20MANLY%20NS&country=AU&institution=AU06703&**mcc=3299**```","schema":{"type":"string"}},{"name":"accountType","in":"query","description":"The Account type from which the transaction was derived.\n```METRO%20PETROLEUM%20FR%20FORE&country=AU&accountType=transaction&institution=AU04301```\n**Valid values:**\n- `transaction` - `credit-card` - `savings` - `mortgage` - `loan` - `foreign`","schema":{"type":"string"}},{"name":"amount","in":"query","description":"The dollar/cent amount relevant to the transaction.\n```q=garfish%20MANLY%20NS&country=AU&institution=AU06703&**amount=-12.95**```","schema":{"type":"string"}}],"responses":{"200":{"description":"The enrich endpoint will always return a 200 response to the user, along with a set of results for each of the datasets subscribed to: category, entity and location. If no results are found for the search query then an empty result set is returned. If parameter inputs are invalid an error is returned.","content":{"application/json":{"schema":{"required":["type","direction","class","links"],"type":"object","properties":{"type":{"type":"string","description":"Value is \"enrich\""},"direction":{"type":"string","description":"Debit or Credit transaction"},"class":{"type":"string","description":"For Debit: payment, bank-fee, cash-withdrawal, transfer, loan-interest. <br/> For Credit: refund, direct-credit, interest, transfer, loan-repayment."},"data":{"type":"object","description":"Container object, containing enrich details.","properties":{"merchant":{"type":"object","properties":{"id":{"type":"string","description":"The merchant id."},"businessName":{"type":"string","description":"The merchant business name."},"website":{"type":"string","description":"The merchant website."},"abn":{"type":"string","description":"Provides the Australian Business Number."},"phoneNumber":{"type":"object","description":"Provides the ```local``` and ```international``` telephone numbers of the merchant.","properties":{"local":{"type":"string"},"international":{"type":"string"}}}}},"category":{"type":"object","properties":{"matchType":{"type":"string","description":"Indicates the method used to match a payment transaction with a merchant or business classification code. Description for each enum; merchantFull: Indicates an exact match between the transaction and a known merchant in the database. merchantPartial: Suggests a partial match with a merchant, usually based on substring or fuzzy logic. mcc: Match is done using the Merchant Category Code associated with the transaction. ml: Match is determined through machine learning algorithms for classification\n","enum":["merchantFull","merchantPartial","mcc","ml"],"example":"merchantfull"},"matchScore":{"type":"string","description":"The confidence score for the matchType which is a float value between 0 and 1. The higher the number, the higher the confidence in the match.","example":"1.0"},"anzsic":{"type":"object","properties":{"division":{"type":"object","description":"Details the code and title of the merchant ANZSIC division.","properties":{"code":{"type":"string"},"title":{"type":"string"}}},"subdivision":{"type":"object","description":"Details the code and title of the merchant ANZSIC subdivision.","properties":{"code":{"type":"string"},"title":{"type":"string"}}},"group":{"type":"object","description":"Details the code and title of the merchant ANZSIC group.","properties":{"code":{"type":"string"},"title":{"type":"string"}}},"class":{"type":"object","description":"Details the code and title of the merchant ANZSIC class.","properties":{"code":{"type":"string"},"title":{"type":"string"}}},"subclass":{"type":"object","properties":{"code":{"type":"string"},"title":{"type":"string"}}}}}}},"location":{"type":"object","properties":{"routeNo":{"type":"string","description":"The street number of the merchant location."},"route":{"type":"string","description":"The street name of the merchant location."},"postalCode":{"type":"string","description":"The post code of the merchant location."},"suburb":{"type":"string","description":"The suburb of the merchant location."},"state":{"type":"string","description":"The state of the merchant location."},"country":{"type":"string","description":"The country of the merchant location."},"formattedAddress":{"type":"string","description":"The full address for the merchant location"},"geometry":{"type":"object","description":"Contains the lat and lng coordinates of the merchant location.","properties":{"lat":{"type":"string"},"lng":{"type":"string"}}}}},"tags":{"type":"array","items":{"type":"string","description":"This array contains tags that are formatted as `tag_name:tag_value`. Each `tag_name` corresponds to a specific category of transaction information, and the `tag_value` provides a detailed classification within that category.\n- For example, the `card` tag_name will have a 4-digit number as tag_value (e.g., \"card:4615\").\n- The `conduct` tag_name can have values like `card`, `overdrawn`, `cheque`, `atm`, `currency`, `late`, `admin`, `dishonour`, `interest` (e.g., \"conduct:cheque\").\n- The `governmentPayment` tag_name might have values such as `centrelink`, `centrelinkCarers`, `crisisSupport`, `education`, `familyAllowance`, `jobseekerPymt`, `medicare`, `newstart`, `pension`, `rentalAssistance`, `vetAffairs`, `youthAllowance` (e.g., \"governmentPayment:centrelink\").\n- The `income` tag_name could include values like `childSupport`, `insurance`, `investment`, `rent`, `salary`, `superannuation` (e.g., \"income:salary\").\n- The `liability` tag_name could include values like `afterpay`, `arl collect pty ltd`, `australian recoveries`, `axess`, `azora`, `baycorp`, `beforepay`, `brighte`, `bundll`, `cash converters`, `cash direct`, `cashngo`, `cash stop`, `cash train`, `ccc`, `cfmg pty ltd`, `charter mercantile`, `cigno`, `collectau`, `collection house`, `complete credit solutions`, `credit collection services`, `credit corp`, `creditline`, `deferit`, `dun and bradstreet`, `earnd`, `edstart`, `finance one`, `fundo`, `fupay`, `gem visa`, `humm`, `indebted`, `klarna`, `latitude`, `laybuy`, `limepay`, `lion finance`, `money3`, `moneyloop`, `mypaynow`, `nimble`, `nine25`, `openpay`, `panthera`, `payitlater`, `payright`, `pioneer credit`, `plenti`, `probe`, `q card`, `quickapay`, `spotmenow`, `sunshine loans`, `tapmypay`, `wagetap`, `wallet wizard`, `zip pay` (e.g., \"liability:afterpay\").\n- The `third-party` tag_name might include values like `apple pay`, `google`, `paypal`, `sp`, `sq` (e.g., \"third-party:paypal\").\n- The `creditCard` tag_name is used with the value `creditCard` (e.g., \"creditCard:creditCard\").\n- The `expense` tag_name is used with the value `rent` (e.g., \"expense:rent\").\n- The `loan` tag_name is used with the value `loan repayment` (e.g., \"loan:loan repayment\").\n- The `mortgage` tag_name could include values like `afg home loans`, `aims`, `amo group`, `athena`, `aussie`, `bluestone`, `clickloans`, `emoney`, `express reverse mortgage`, `firstmac`, `fox symes`, `freedom lend`, `freedom loans`, `funding`, `heartland reverse mortgages`, `homeloans`, `homestar`, `homestart`, `household capital`, `illawarra home loans`, `keystart`, `la trobe financial`, `liberty financial`, `loans`, `mortgage house`, `mortgage offset`, `mortgageport`, `mortgage repayment`, `onetwo`, `online home loans`, `pacific mortgage group`, `pepper money`, `qantas money`, `reduce home loans`, `resi`, `resimac`, `sucasa`, `switzer home loans`, `ticToc`, `unloan`, `vmg`, `well money` (e.g., \"mortgage:afg home loans\").\n"},"description":"This field contains an array of strings, each representing a specific tag for the transaction. The format of each string should be `tag_name:tag_value`, where `tag_name` defines the type of transaction (e.g., `card`, `income`, `mortgage`), and `tag_value` provides additional details (e.g., \"card:4615\"). The tags help classify and identify transactions based on various criteria.\n\n      - card:4615\n      - conduct:card\n      - conduct:overdrawn\n      - conduct:cheque\n      - conduct:atm\n      - conduct:currency\n      - conduct:late\n      - conduct:admin\n      - conduct:dishonour\n      - conduct:interest\n      - governmentPayment:centrelink\n      - governmentPayment:centrelinkCarers\n      - governmentPayment:crisisSupport\n      - governmentPayment:education\n      - governmentPayment:familyAllowance\n      - governmentPayment:jobseekerPymt\n      - governmentPayment:medicare\n      - governmentPayment:newstart\n      - governmentPayment:pension\n      - governmentPayment:rentalAssistance\n      - governmentPayment:vetAffairs\n      - governmentPayment:youthAllowance\n      - income:childSupport\n      - income:insurance\n      - income:investment\n      - income:rent\n      - income:salary\n      - income:superannuation\n      - liability:afterpay\n      - liability:arl collect pty ltd\n      - liability:australian recoveries\n      - liability:axess\n      - liability:azora\n      - liability:baycorp\n      - liability:beforepay\n      - liability:brighte\n      - liability:bundll\n      - liability:cash converters\n      - liability:cash direct\n      - liability:cashngo\n      - liability:cash stop\n      - liability:cash train\n      - liability:ccc\n      - liability:cfmg pty ltd\n      - liability:charter mercantile\n      - liability:cigno\n      - liability:collectau\n      - liability:collection house\n      - liability:complete credit solutions\n      - liability:credit collection services\n      - liability:credit corp\n      - liability:creditline\n      - liability:deferit\n      - liability:dun and bradstreet\n      - liability:earnd\n      - liability:edstart\n      - liability:finance one\n      - liability:fundo\n      - liability:fupay\n      - liability:gem visa\n      - liability:humm\n      - liability:indebted\n      - liability:klarna\n      - liability:latitude\n      - liability:laybuy\n      - liability:limepay\n      - liability:lion finance\n      - liability:money3\n      - liability:moneyloop\n      - liability:mypaynow\n      - liability:nimble\n      - liability:nine25\n      - liability:openpay\n      - liability:panthera\n      - liability:payitlater\n      - liability:payright\n      - liability:pioneer credit\n      - liability:plenti\n      - liability:probe\n      - liability:q card\n      - liability:quickapay\n      - liability:spotmenow\n      - liability:sunshine loans\n      - liability:tapmypay\n      - liability:wagetap\n      - liability:wallet wizard\n      - liability:zip pay\n      - third-party:apple pay\n      - third-party:google\n      - third-party:paypal\n      - third-party:sp\n      - third-party:sq\n      - creditCard:creditCard\n      - expense:rent\n      - loan:loan repayment\n      - mortgage:afg home loans\n      - mortgage:aims\n      - mortgage:amo group\n      - mortgage:athena\n      - mortgage:aussie\n      - mortgage:bluestone\n      - mortgage:clickloans\n      - mortgage:emoney\n      - mortgage:express reverse mortgage\n      - mortgage:firstmac\n      - mortgage:fox symes\n      - mortgage:freedom lend\n      - mortgage:freedom loans\n      - mortgage:funding\n      - mortgage:heartland reverse mortgages\n      - mortgage:homeloans\n      - mortgage:homestar\n      - mortgage:homestart\n      - mortgage:household capital\n      - mortgage:illawarra home loans\n      - mortgage:keystart\n      - mortgage:la trobe financial\n      - mortgage:liberty financial\n      - mortgage:loans\n      - mortgage:mortgage house\n      - mortgage:mortgage offset\n      - mortgage:mortgageport\n      - mortgage:mortgage repayment\n      - mortgage:onetwo\n      - mortgage:online home loans\n      - mortgage:pacific mortgage group\n      - mortgage:pepper money\n      - mortgage:qantas money\n      - mortgage:reduce home loans\n      - mortgage:resi\n      - mortgage:resimac\n      - mortgage:sucasa\n      - mortgage:switzer home loans\n      - mortgage:ticToc\n      - mortgage:unloan\n      - mortgage:vmg\n      - mortgage:well money\n"}}},"links":{"type":"object","properties":{"self":{"type":"string","description":"Provides a reference link to the original query."},"logo-master":{"type":"string","description":"Provides link to master logo. Logos are provided in a variety of formats: .svg, .png, .jpg, jpeg, gif. Where null no merchant logo is available."},"logo-thumb":{"type":"string","description":"Provides link to thumb logo (where no thumb available master logo is returned for both). Logos are provided in a variety of formats: .svg, .png, .jpg, jpeg, gif. Where null no merchant logo is available."}}}},"x-readme-ref-name":"Enrich"},"example":{"type":"enrich","direction":"debit","class":"payment","data":{"merchant":{"id":"f0ff1071-6a1a-45d6-b7af-8be668a3411a","businessName":"Woolworths","website":"https://www.woolworths.com.au/shop/storelocator/nsw-shellharbour-1197?utm_source=google&utm_medium=organic&utm_campaign=googleplaces","abn":"88000014675","phoneNumber":{"local":"(02) 4276 6018","international":"+61 2 4276 6018"}},"category":{"matchType":"merchantFull","matchScore":"1.0","anzsic":{"division":{"code":"G","title":"Retail Trade"},"subdivision":{"code":"41","title":"Food Retailing"},"group":{"code":"411","title":"Supermarket and Grocery Stores"},"class":{"code":"4110","title":"Supermarket and Grocery Stores"},"subclass":{"code":"411000","title":"Supermarket and Grocery Stores"}}},"location":{"routeNo":"29","route":"E Esplanade","postalCode":"2095","suburb":"NSW","state":"MANLY","country":"Australia","formattedAddress":"1/39 E Esplanade, Manly NSW 2095","geometry":{"lat":"-33.79988520000001","lng":"151.2858021"}},"tags":["conduct:dishonour"]},"links":{"self":"https://au-api.basiq.io/enrich?country=AU&institution=AU00000&q=WOOLWORTHS","logo-master":"https://enrich-enrichmerchantslogobucket-6or17iuhdvs9.s3-ap-southeast-2.amazonaws.com/woolworths-master.svg","logo-thumb":"https://enrich-enrichmerchantslogobucket-6or17iuhdvs9.s3-ap-southeast-2.amazonaws.com/woolworths-thumb.svg"}}}}},"400":{"description":"Returns error that server cannot or will not process the request due to something that is perceived to be a client error.","content":{"application/json":{"schema":{"required":["correlationId","data","type"],"type":"object","properties":{"type":{"type":"string","description":"Always \"list\".","example":"list"},"correlationId":{"type":"string","description":"Unique identifier for this particular occurrence of the problem.","example":"ac5ah5i"},"data":{"type":"array","description":"Error data.","items":{"required":["code","type"],"type":"object","properties":{"type":{"type":"string","description":"Type of the response, always \"error\"","example":"error"},"title":{"type":"string","description":"Title of the error","example":"Parameter not valid."},"code":{"type":"string","description":"Application-specific error code, expressed as a string value.","example":"parameter-not-valid","enum":["parameter-not-supplied","parameter-not-valid","unsupported-accept","invalid-content","institution-not-supported","invalid-credentials"]},"detail":{"type":"string","description":"Human-readable explanation specific to this occurrence of the problem.","example":"ID value is not valid."},"source":{"title":"Source","type":"object","properties":{"parameter":{"type":"string","description":"String indicating which URI query parameter caused the error.","example":"id"}},"description":"An object containing references to the source of the error.","x-readme-ref-name":"Source"}}}}},"x-readme-ref-name":"BadRequestError"},"examples":{"Bad Request":{"value":{"type":"list","correlationId":"ac5ah5i","data":[{"type":"error","title":"Parameter not valid.","code":"parameter-not-valid","detail":"ID value is not valid.","source":{"parameter":"id"}}]}},"Invalid Filters":{"value":{"type":"list","correlationId":"ac5ah55","data":[{"type":"error","code":"parameter-not-valid","title":"Parameter value is not valid","detail":"The provided filter parameter is in invalid format or unsupported","source":{"parameter":"filter"}}]}}}}}},"403":{"description":"Error that access is forbidden and tied to the application logic, such as insufficient rights to a resource.","content":{"application/json":{"schema":{"required":["correlationId","data","type"],"type":"object","properties":{"type":{"type":"string","description":"Always \"list\".","example":"list"},"correlationId":{"type":"string","description":"Unique identifier for this particular occurrence of the problem.","example":"ac5ah5i"},"data":{"type":"array","description":"Error data.","items":{"required":["code","source","type"],"type":"object","properties":{"type":{"type":"string","description":"Type of the response, always \"error\"","example":"error"},"title":{"type":"string","description":"Title of the error","example":"Forbidden Access"},"code":{"type":"string","description":"Application-specific error code, expressed as a string value.","example":"forbidden-access","enum":["forbidden-access","no-production-access","access-denied"]},"detail":{"type":"string","description":"Human-readable explanation specific to this occurrence of the problem.","example":"Access to this resource is forbidden."},"source":{"title":"Source","type":"object","properties":{"parameter":{"type":"string","description":"String indicating which URI query parameter caused the error.","example":"id"}},"description":"An object containing references to the source of the error.","x-readme-ref-name":"Source"}}}}},"x-readme-ref-name":"ForbiddenAccessError"}}}},"500":{"description":"Returns error response code indicates that the server encountered an unexpected condition that prevented it from fulfilling the request.","content":{"application/json":{"schema":{"required":["correlationId","data","type"],"type":"object","properties":{"type":{"type":"string","description":"Always \"list\".","example":"list"},"correlationId":{"type":"string","description":"Unique identifier for this particular occurrence of the problem.","example":"ac5ah5i"},"data":{"type":"array","description":"Error data.","items":{"required":["code","type"],"type":"object","properties":{"code":{"type":"string","description":"Application-specific error code, expressed as a string value.","example":"internal-server-error","enum":["internal-server-error"]},"detail":{"type":"string","description":"Human-readable explanation specific to this occurrence of the problem.","example":"Internal Server error. Contact support."},"title":{"type":"string","description":"Title of the error","example":"Internal Server error."},"type":{"type":"string","description":"Type of the response, always \"error\"","example":"error"}}}}},"x-readme-ref-name":"InternalServerError"}}}}},"security":[{"services_token":[]}]}},"/merchants":{"get":{"tags":["Enrich"],"summary":"Search Merchants","operationId":"MerchantSearch","description":"Retrieves merchant details. At least one of `abn` or `merchantName` is required for a successful search. Optional filters for suburb and entity type can also be applied.","parameters":[{"name":"abn","in":"query","description":"The Australian Business Number (ABN) of the merchant. Required if `merchantName` is not provided.","schema":{"type":"string"},"required":false,"example":"38865358328"},{"name":"merchantName","in":"query","description":"The name of the merchant. Required if `abn` is not provided.","schema":{"type":"string"},"required":false,"example":"coles"},{"name":"suburb","in":"query","description":"The suburb of the merchant location to filter by.","schema":{"type":"string"},"required":false,"example":"Ryde"},{"name":"entityType","in":"query","description":"The type of the merchant entity to filter by.","schema":{"type":"string"},"required":false,"example":"Individual/Sole Trader"}],"responses":{"200":{"description":"Successful response with merchant data.","content":{"application/json":{"schema":{"type":"object","required":["type","size","data","links"],"properties":{"type":{"type":"string","description":"Always 'list'.","example":"list"},"size":{"type":"integer","description":"The number of merchants returned.","example":1},"data":{"type":"array","description":"Array of merchant objects.","items":{"$ref":"#/components/schemas/MerchantDetails"}},"links":{"type":"object","properties":{"self":{"type":"string","description":"A link to the current query.","example":"https://au-api.basiq.io/merchants?abn=38865358328&merchantName=coles&suburb=Ryde&entityType=Individual%2FSole%20Trader"}}}}},"examples":{"Successful Response with Data":{"value":{"type":"list","size":1,"data":[{"merchantName":"Coles","merchantId":"c1ef352e-c807-4bdc-9a70-887f7cc17426","matchScore":1,"suburb":null,"state":"NSW","country":"Australia","abn":"38865358328","entityType":"Individual/Sole Trader"}],"links":{"self":"https://au-api.basiq.io/merchants?abn=38865358328&merchantName=coles&suburb=Ryde&entityType=Individual%2FSole%20Trader"}}},"No Results Found":{"value":{"type":"list","size":0,"data":[],"links":{"self":"https://au-api.basiq.io/merchants?abn=38865358328&entityType=Individual%2FSole+Trader&merchantName=coles&suburb=Ryde"}}}}}}}},"security":[{"services_token":[]}]}},"/merchants/{merchantId}":{"get":{"tags":["Enrich"],"summary":"Retrieve a merchant","operationId":"GetMerchantById","description":"Retrieves a single merchant's details using its unique ID.","parameters":[{"name":"merchantId","in":"path","description":"The unique identifier of the merchant.","schema":{"type":"string","format":"uuid"},"required":true,"example":"c1ef352e-c807-4bdc-9a70-887f7cc17426"}],"responses":{"200":{"description":"Successful response with a single merchant's detailed data.","content":{"application/json":{"schema":{"$ref":"#/components/schemas/SingleMerchantResponse"},"example":{"source":"enrich","merchant":{"id":"c1ef352e-c807-4bdc-9a70-887f7cc17426","businessName":"Coles","website":"","abn":"38865358328","phoneNumber":{"local":"","international":""}},"category":{"matchType":"merchantFull","matchScore":1,"anzsic":{"division":{"code":"0","title":"Unknown"},"subdivision":{"code":"0","title":"Unknown"},"group":{"code":"0","title":"Unknown"},"class":{"code":"0","title":"Unknown"},"subclass":{"code":"0","title":"Unknown"}}},"location":{"routeNo":"","route":"","postalCode":"2257","suburb":"","state":"NSW","country":"Australia","formattedAddress":"","geometry":{"lat":"","lng":""}},"links":{"self":"https://au-api.basiq.io/merchants/c1ef352e-c807-4bdc-9a70-887f7cc17426","logo-master":null,"logo-thumb":null}}}}},"404":{"description":"Merchant not found.","content":{"application/json":{"schema":{"$ref":"#/components/schemas/MerchantNotFoundError"},"example":{"type":"list","correlationId":"85a07b07-46a9-4805-8bab-67f5f1c421e8","data":[{"type":"error","code":"resource-not-found","title":"Requested resource is not found","detail":"Merchant not found"}]}}}}},"security":[{"services_token":[]}]}}},"components":{"schemas":{"MerchantDetails":{"type":"object","properties":{"merchantName":{"type":"string","description":"The name of the merchant.","example":"Coles"},"merchantId":{"type":"string","description":"Unique identifier for the merchant.","example":"c1ef352e-c807-4bdc-9a70-887f7cc17426"},"matchScore":{"type":"number","format":"float","description":"Confidence score of the match.","example":1},"suburb":{"type":"string","nullable":true,"description":"The suburb of the merchant location, or null if not available.","example":null},"state":{"type":"string","description":"The state of the merchant location.","example":"NSW"},"country":{"type":"string","description":"The country of the merchant location.","example":"Australia"},"abn":{"type":"string","description":"The Australian Business Number (ABN) of the merchant.","example":"38865358328"},"entityType":{"type":"string","description":"The type of the merchant entity.","example":"Individual/Sole Trader"}}},"SingleMerchantResponse":{"type":"object","properties":{"source":{"type":"string","example":"enrich"},"merchant":{"type":"object","properties":{"id":{"type":"string","description":"The merchant id."},"businessName":{"type":"string","description":"The merchant business name."},"website":{"type":"string","description":"The merchant website."},"abn":{"type":"string","description":"Provides the Australian Business Number."},"phoneNumber":{"type":"object","description":"Provides the local and international telephone numbers of the merchant.","properties":{"local":{"type":"string"},"international":{"type":"string"}}}}},"category":{"type":"object","properties":{"matchType":{"type":"string","description":"Indicates the method used to match a payment transaction with a merchant or business classification code.","enum":["merchantFull","merchantPartial","mcc","ml"]},"matchScore":{"type":"number","format":"float","description":"The confidence score for the matchType which is a float value between 0 and 1."},"anzsic":{"type":"object","properties":{"division":{"type":"object","properties":{"code":{"type":"string"},"title":{"type":"string"}}},"subdivision":{"type":"object","properties":{"code":{"type":"string"},"title":{"type":"string"}}},"group":{"type":"object","properties":{"code":{"type":"string"},"title":{"type":"string"}}},"class":{"type":"object","properties":{"code":{"type":"string"},"title":{"type":"string"}}},"subclass":{"type":"object","properties":{"code":{"type":"string"},"title":{"type":"string"}}}}}}},"location":{"type":"object","properties":{"routeNo":{"type":"string"},"route":{"type":"string"},"postalCode":{"type":"string"},"suburb":{"type":"string"},"state":{"type":"string"},"country":{"type":"string"},"formattedAddress":{"type":"string"},"geometry":{"type":"object","properties":{"lat":{"type":"string"},"lng":{"type":"string"}}}}},"links":{"type":"object","properties":{"self":{"type":"string","description":"Provides a reference link to the original query."},"logo-master":{"type":"string","nullable":true,"description":"Provides link to master logo. Where null no merchant logo is available."},"logo-thumb":{"type":"string","nullable":true,"description":"Provides link to thumb logo. Where null no merchant logo is available."}}}}},"MerchantNotFoundError":{"type":"object","required":["correlationId","data","type"],"properties":{"type":{"type":"string","description":"Always \"list\".","example":"list"},"correlationId":{"type":"string","description":"Unique identifier for this particular occurrence of the problem.","example":"85a07b07-46a9-4805-8bab-67f5f1c421e8"},"data":{"type":"array","description":"Error data.","items":{"type":"object","required":["code","type"],"properties":{"type":{"type":"string","description":"Type of the response, always \"error\"","example":"error"},"title":{"type":"string","description":"Title of the error","example":"Requested resource is not found"},"code":{"type":"string","description":"Application-specific error code, expressed as a string value.","example":"resource-not-found","enum":["resource-not-found"]},"detail":{"type":"string","description":"Human-readable explanation specific to this occurrence of the problem.","example":"Merchant not found"}}}}}}},"securitySchemes":{"services_token":{"type":"http","scheme":"bearer","bearerFormat":"JWT"}}},"security":[{"services_token":[]}],"x-readme":{"explorer-enabled":true,"proxy-enabled":true,"samples-enabled":true,"samples-languages":["curl","node","ruby","javascript","python"]}}
+{
+    "openapi": "3.0.1",
+    "info": {
+        "title": "Enrich",
+        "description": "All included utility endpoints for Basiq partners",
+        "version": "3.0.0",
+        "license": {
+            "name": "Commercial",
+            "url": "https://basiq.io"
+        }
+    },
+    "servers": [
+        {
+            "url": "https://au-api.basiq.io"
+        }
+    ],
+    "paths": {
+        "/enrich": {
+            "get": {
+                "tags": [
+                    "Enrich"
+                ],
+                "summary": "Enrich",
+                "operationId": "Enrich",
+                "description": "The Enrich resource enables you to retrieve details by passing in a search query containing a bank transaction description. The service enriches transaction data with multiple attributes, returning a transaction classification and three metadata components. The transaction classification will first determine if the transaction is of type payment, transfer, cash-withdrawal, bank-fee etc. The engine then derives merchant information, purchase location and prescribes an industry standard categorisation for each payment transaction.",
+                "parameters": [
+                    {
+                        "name": "q",
+                        "in": "query",
+                        "description": "This is the search string that is used to lookup the entity (merchant) information.\n```**q=garfish%20MANLY%20NS**&country=AU&institution=AU06703```",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true
+                    },
+                    {
+                        "name": "institution",
+                        "in": "query",
+                        "description": "Identifies the institution from where the transaction was derived. This must be a Basiq recognisable institution ID.\n```enrich?METRO%20PETROLEUM%20FR%20FORE&country=AU&accountType=transaction&amount=-12.95&**institution=AU04301**```",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true
+                    },
+                    {
+                        "name": "country",
+                        "in": "query",
+                        "description": "Specifies the country the search should be narrowed down to. Passing in a country value will limit the search to the specified country. The country must be in ISO 3166 Alpha-2 format\n```q=garfish%20MANLY%20NS&**country=AU**&institution=AU06703```",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true
+                    },
+                    {
+                        "name": "mcc",
+                        "in": "query",
+                        "description": "Merchant classification code as defined by Visa and Mastercard\n```q=garfish%20MANLY%20NS&country=AU&institution=AU06703&**mcc=3299**```",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "accountType",
+                        "in": "query",
+                        "description": "The Account type from which the transaction was derived.\n```METRO%20PETROLEUM%20FR%20FORE&country=AU&accountType=transaction&institution=AU04301```\n**Valid values:**\n- `transaction` - `credit-card` - `savings` - `mortgage` - `loan` - `foreign`",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "amount",
+                        "in": "query",
+                        "description": "The dollar/cent amount relevant to the transaction.\n```q=garfish%20MANLY%20NS&country=AU&institution=AU06703&**amount=-12.95**```",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "The enrich endpoint will always return a 200 response to the user, along with a set of results for each of the datasets subscribed to: category, entity and location. If no results are found for the search query then an empty result set is returned. If parameter inputs are invalid an error is returned.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "required": [
+                                        "type",
+                                        "direction",
+                                        "class",
+                                        "links"
+                                    ],
+                                    "type": "object",
+                                    "properties": {
+                                        "type": {
+                                            "type": "string",
+                                            "description": "Value is \"enrich\""
+                                        },
+                                        "direction": {
+                                            "type": "string",
+                                            "description": "Debit or Credit transaction"
+                                        },
+                                        "class": {
+                                            "type": "string",
+                                            "description": "For Debit: payment, bank-fee, cash-withdrawal, transfer, loan-interest. <br/> For Credit: refund, direct-credit, interest, transfer, loan-repayment."
+                                        },
+                                        "data": {
+                                            "type": "object",
+                                            "description": "Container object, containing enrich details.",
+                                            "properties": {
+                                                "merchant": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "id": {
+                                                            "type": "string",
+                                                            "description": "The merchant id."
+                                                        },
+                                                        "businessName": {
+                                                            "type": "string",
+                                                            "description": "The merchant business name."
+                                                        },
+                                                        "website": {
+                                                            "type": "string",
+                                                            "description": "The merchant website."
+                                                        },
+                                                        "abn": {
+                                                            "type": "string",
+                                                            "description": "Provides the Australian Business Number."
+                                                        },
+                                                        "phoneNumber": {
+                                                            "type": "object",
+                                                            "description": "Provides the ```local``` and ```international``` telephone numbers of the merchant.",
+                                                            "properties": {
+                                                                "local": {
+                                                                    "type": "string"
+                                                                },
+                                                                "international": {
+                                                                    "type": "string"
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                "category": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "matchType": {
+                                                            "type": "string",
+                                                            "description": "Indicates the method used to match a payment transaction with a merchant or business classification code. Description for each enum; merchantFull: Indicates an exact match between the transaction and a known merchant in the database. merchantPartial: Suggests a partial match with a merchant, usually based on substring or fuzzy logic. mcc: Match is done using the Merchant Category Code associated with the transaction. ml: Match is determined through machine learning algorithms for classification\n",
+                                                            "enum": [
+                                                                "merchantFull",
+                                                                "merchantPartial",
+                                                                "mcc",
+                                                                "ml"
+                                                            ],
+                                                            "example": "merchantfull"
+                                                        },
+                                                        "matchScore": {
+                                                            "type": "string",
+                                                            "description": "The confidence score for the matchType which is a float value between 0 and 1. The higher the number, the higher the confidence in the match.",
+                                                            "example": "1.0"
+                                                        },
+                                                        "anzsic": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "division": {
+                                                                    "type": "object",
+                                                                    "description": "Details the code and title of the merchant ANZSIC division.",
+                                                                    "properties": {
+                                                                        "code": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "title": {
+                                                                            "type": "string"
+                                                                        }
+                                                                    }
+                                                                },
+                                                                "subdivision": {
+                                                                    "type": "object",
+                                                                    "description": "Details the code and title of the merchant ANZSIC subdivision.",
+                                                                    "properties": {
+                                                                        "code": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "title": {
+                                                                            "type": "string"
+                                                                        }
+                                                                    }
+                                                                },
+                                                                "group": {
+                                                                    "type": "object",
+                                                                    "description": "Details the code and title of the merchant ANZSIC group.",
+                                                                    "properties": {
+                                                                        "code": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "title": {
+                                                                            "type": "string"
+                                                                        }
+                                                                    }
+                                                                },
+                                                                "class": {
+                                                                    "type": "object",
+                                                                    "description": "Details the code and title of the merchant ANZSIC class.",
+                                                                    "properties": {
+                                                                        "code": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "title": {
+                                                                            "type": "string"
+                                                                        }
+                                                                    }
+                                                                },
+                                                                "subclass": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "code": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "title": {
+                                                                            "type": "string"
+                                                                        }
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                "location": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "routeNo": {
+                                                            "type": "string",
+                                                            "description": "The street number of the merchant location."
+                                                        },
+                                                        "route": {
+                                                            "type": "string",
+                                                            "description": "The street name of the merchant location."
+                                                        },
+                                                        "postalCode": {
+                                                            "type": "string",
+                                                            "description": "The post code of the merchant location."
+                                                        },
+                                                        "suburb": {
+                                                            "type": "string",
+                                                            "description": "The suburb of the merchant location."
+                                                        },
+                                                        "state": {
+                                                            "type": "string",
+                                                            "description": "The state of the merchant location."
+                                                        },
+                                                        "country": {
+                                                            "type": "string",
+                                                            "description": "The country of the merchant location."
+                                                        },
+                                                        "formattedAddress": {
+                                                            "type": "string",
+                                                            "description": "The full address for the merchant location"
+                                                        },
+                                                        "geometry": {
+                                                            "type": "object",
+                                                            "description": "Contains the lat and lng coordinates of the merchant location.",
+                                                            "properties": {
+                                                                "lat": {
+                                                                    "type": "string"
+                                                                },
+                                                                "lng": {
+                                                                    "type": "string"
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                "tags": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "string",
+                                                        "description": "This array contains tags that are formatted as `tag_name:tag_value`. Each `tag_name` corresponds to a specific category of transaction information, and the `tag_value` provides a detailed classification within that category.\n- For example, the `card` tag_name will have a 4-digit number as tag_value (e.g., \"card:4615\").\n- The `conduct` tag_name can have values like `card`, `overdrawn`, `cheque`, `atm`, `currency`, `late`, `admin`, `dishonour`, `interest` (e.g., \"conduct:cheque\").\n- The `governmentPayment` tag_name might have values such as `centrelink`, `centrelinkCarers`, `crisisSupport`, `education`, `familyAllowance`, `jobseekerPymt`, `medicare`, `newstart`, `pension`, `rentalAssistance`, `vetAffairs`, `youthAllowance` (e.g., \"governmentPayment:centrelink\").\n- The `income` tag_name could include values like `childSupport`, `insurance`, `investment`, `rent`, `salary`, `superannuation` (e.g., \"income:salary\").\n- The `liability` tag_name could include values like `afterpay`, `arl collect pty ltd`, `australian recoveries`, `axess`, `azora`, `baycorp`, `beforepay`, `brighte`, `bundll`, `cash converters`, `cash direct`, `cashngo`, `cash stop`, `cash train`, `ccc`, `cfmg pty ltd`, `charter mercantile`, `cigno`, `collectau`, `collection house`, `complete credit solutions`, `credit collection services`, `credit corp`, `creditline`, `deferit`, `dun and bradstreet`, `earnd`, `edstart`, `finance one`, `fundo`, `fupay`, `gem visa`, `humm`, `indebted`, `klarna`, `latitude`, `laybuy`, `limepay`, `lion finance`, `money3`, `moneyloop`, `mypaynow`, `nimble`, `nine25`, `openpay`, `panthera`, `payitlater`, `payright`, `pioneer credit`, `plenti`, `probe`, `q card`, `quickapay`, `spotmenow`, `sunshine loans`, `tapmypay`, `wagetap`, `wallet wizard`, `zip pay` (e.g., \"liability:afterpay\").\n- The `third-party` tag_name might include values like `apple pay`, `google`, `paypal`, `sp`, `sq` (e.g., \"third-party:paypal\").\n- The `creditCard` tag_name is used with the value `creditCard` (e.g., \"creditCard:creditCard\").\n- The `expense` tag_name is used with the value `rent` (e.g., \"expense:rent\").\n- The `loan` tag_name is used with the value `loan repayment` (e.g., \"loan:loan repayment\").\n- The `mortgage` tag_name could include values like `afg home loans`, `aims`, `amo group`, `athena`, `aussie`, `bluestone`, `clickloans`, `emoney`, `express reverse mortgage`, `firstmac`, `fox symes`, `freedom lend`, `freedom loans`, `funding`, `heartland reverse mortgages`, `homeloans`, `homestar`, `homestart`, `household capital`, `illawarra home loans`, `keystart`, `la trobe financial`, `liberty financial`, `loans`, `mortgage house`, `mortgage offset`, `mortgageport`, `mortgage repayment`, `onetwo`, `online home loans`, `pacific mortgage group`, `pepper money`, `qantas money`, `reduce home loans`, `resi`, `resimac`, `sucasa`, `switzer home loans`, `ticToc`, `unloan`, `vmg`, `well money` (e.g., \"mortgage:afg home loans\").\n"
+                                                    },
+                                                    "description": "This field contains an array of strings, each representing a specific tag for the transaction. The format of each string should be `tag_name:tag_value`, where `tag_name` defines the type of transaction (e.g., `card`, `income`, `mortgage`), and `tag_value` provides additional details (e.g., \"card:4615\"). The tags help classify and identify transactions based on various criteria.\n\n  - card:4615\n  - conduct:card\n  - conduct:overdrawn\n  - conduct:cheque\n  - conduct:atm\n  - conduct:currency\n  - conduct:late\n  - conduct:admin\n  - conduct:dishonour\n  - conduct:interest\n  - governmentPayment:centrelink\n  - governmentPayment:centrelinkCarers\n  - governmentPayment:crisisSupport\n  - governmentPayment:education\n  - governmentPayment:familyAllowance\n  - governmentPayment:jobseekerPymt\n  - governmentPayment:medicare\n  - governmentPayment:newstart\n  - governmentPayment:pension\n  - governmentPayment:rentalAssistance\n  - governmentPayment:vetAffairs\n  - governmentPayment:youthAllowance\n  - governmentPayment:familyTaxBenefit\n  - governmentPayment:stillbornPymt\n  - governmentPayment:childCareSubsidy\n  - governmentPayment:parentalLeavePymt\n  - governmentPayment:parentingPymt\n  - governmentPayment:disabilitySupport\n  - governmentPayment:pensionerEducationSupplement\n  - governmentPayment:farmAllowance\n  - governmentPayment:disasterPymt\n  - income:childSupport\n  - income:insurance\n  - income:investment\n  - income:rent\n  - income:salary\n  - income:superannuation\n  - liability:afterpay\n  - liability:arl collect pty ltd\n  - liability:australian recoveries\n  - liability:axess\n  - liability:azora\n  - liability:baycorp\n  - liability:beforepay\n  - liability:brighte\n  - liability:bundll\n  - liability:cash converters\n  - liability:cash direct\n  - liability:cashngo\n  - liability:cash stop\n  - liability:cash train\n  - liability:ccc\n  - liability:cfmg pty ltd\n  - liability:charter mercantile\n  - liability:cigno\n  - liability:collectau\n  - liability:collection house\n  - liability:complete credit solutions\n  - liability:credit collection services\n  - liability:credit corp\n  - liability:creditline\n  - liability:deferit\n  - liability:dun and bradstreet\n  - liability:earnd\n  - liability:edstart\n  - liability:finance one\n  - liability:fundo\n  - liability:fupay\n  - liability:gem visa\n  - liability:humm\n  - liability:indebted\n  - liability:klarna\n  - liability:latitude\n  - liability:laybuy\n  - liability:limepay\n  - liability:lion finance\n  - liability:money3\n  - liability:moneyloop\n  - liability:mypaynow\n  - liability:nimble\n  - liability:nine25\n  - liability:openpay\n  - liability:panthera\n  - liability:payitlater\n  - liability:payright\n  - liability:pioneer credit\n  - liability:plenti\n  - liability:probe\n  - liability:q card\n  - liability:quickapay\n  - liability:spotmenow\n  - liability:sunshine loans\n  - liability:tapmypay\n  - liability:wagetap\n  - liability:wallet wizard\n  - liability:zip pay\n  - third-party:apple pay\n  - third-party:google\n  - third-party:paypal\n  - third-party:sp\n  - third-party:sq\n  - creditCard:creditCard\n  - expense:rent\n  - loan:loan repayment\n  - mortgage:afg home loans\n  - mortgage:aims\n  - mortgage:amo group\n  - mortgage:athena\n  - mortgage:aussie\n  - mortgage:bluestone\n  - mortgage:clickloans\n  - mortgage:emoney\n  - mortgage:express reverse mortgage\n  - mortgage:firstmac\n  - mortgage:fox symes\n  - mortgage:freedom lend\n  - mortgage:freedom loans\n  - mortgage:funding\n  - mortgage:heartland reverse mortgages\n  - mortgage:homeloans\n  - mortgage:homestar\n  - mortgage:homestart\n  - mortgage:household capital\n  - mortgage:illawarra home loans\n  - mortgage:keystart\n  - mortgage:la trobe financial\n  - mortgage:liberty financial\n  - mortgage:loans\n  - mortgage:mortgage house\n  - mortgage:mortgage offset\n  - mortgage:mortgageport\n  - mortgage:mortgage repayment\n  - mortgage:onetwo\n  - mortgage:online home loans\n  - mortgage:pacific mortgage group\n  - mortgage:pepper money\n  - mortgage:qantas money\n  - mortgage:reduce home loans\n  - mortgage:resi\n  - mortgage:resimac\n  - mortgage:sucasa\n  - mortgage:switzer home loans\n  - mortgage:ticToc\n  - mortgage:unloan\n  - mortgage:vmg\n  - mortgage:well money"
+                                                }
+                                            }
+                                        },
+                                        "links": {
+                                            "type": "object",
+                                            "properties": {
+                                                "self": {
+                                                    "type": "string",
+                                                    "description": "Provides a reference link to the original query."
+                                                },
+                                                "logo-master": {
+                                                    "type": "string",
+                                                    "description": "Provides link to master logo. Logos are provided in a variety of formats: .svg, .png, .jpg, jpeg, gif. Where null no merchant logo is available."
+                                                },
+                                                "logo-thumb": {
+                                                    "type": "string",
+                                                    "description": "Provides link to thumb logo (where no thumb available master logo is returned for both). Logos are provided in a variety of formats: .svg, .png, .jpg, jpeg, gif. Where null no merchant logo is available."
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "x-readme-ref-name": "Enrich"
+                                },
+                                "example": {
+                                    "type": "enrich",
+                                    "direction": "debit",
+                                    "class": "payment",
+                                    "data": {
+                                        "merchant": {
+                                            "id": "f0ff1071-6a1a-45d6-b7af-8be668a3411a",
+                                            "businessName": "Woolworths",
+                                            "website": "https://www.woolworths.com.au/shop/storelocator/nsw-shellharbour-1197?utm_source=google&utm_medium=organic&utm_campaign=googleplaces",
+                                            "abn": "88000014675",
+                                            "phoneNumber": {
+                                                "local": "(02) 4276 6018",
+                                                "international": "+61 2 4276 6018"
+                                            }
+                                        },
+                                        "category": {
+                                            "matchType": "merchantFull",
+                                            "matchScore": "1.0",
+                                            "anzsic": {
+                                                "division": {
+                                                    "code": "G",
+                                                    "title": "Retail Trade"
+                                                },
+                                                "subdivision": {
+                                                    "code": "41",
+                                                    "title": "Food Retailing"
+                                                },
+                                                "group": {
+                                                    "code": "411",
+                                                    "title": "Supermarket and Grocery Stores"
+                                                },
+                                                "class": {
+                                                    "code": "4110",
+                                                    "title": "Supermarket and Grocery Stores"
+                                                },
+                                                "subclass": {
+                                                    "code": "411000",
+                                                    "title": "Supermarket and Grocery Stores"
+                                                }
+                                            }
+                                        },
+                                        "location": {
+                                            "routeNo": "29",
+                                            "route": "E Esplanade",
+                                            "postalCode": "2095",
+                                            "suburb": "NSW",
+                                            "state": "MANLY",
+                                            "country": "Australia",
+                                            "formattedAddress": "1/39 E Esplanade, Manly NSW 2095",
+                                            "geometry": {
+                                                "lat": "-33.79988520000001",
+                                                "lng": "151.2858021"
+                                            }
+                                        },
+                                        "tags": [
+                                            "conduct:dishonour"
+                                        ]
+                                    },
+                                    "links": {
+                                        "self": "https://au-api.basiq.io/enrich?country=AU&institution=AU00000&q=WOOLWORTHS",
+                                        "logo-master": "https://enrich-enrichmerchantslogobucket-6or17iuhdvs9.s3-ap-southeast-2.amazonaws.com/woolworths-master.svg",
+                                        "logo-thumb": "https://enrich-enrichmerchantslogobucket-6or17iuhdvs9.s3-ap-southeast-2.amazonaws.com/woolworths-thumb.svg"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Returns error that server cannot or will not process the request due to something that is perceived to be a client error.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "required": [
+                                        "correlationId",
+                                        "data",
+                                        "type"
+                                    ],
+                                    "type": "object",
+                                    "properties": {
+                                        "type": {
+                                            "type": "string",
+                                            "description": "Always \"list\".",
+                                            "example": "list"
+                                        },
+                                        "correlationId": {
+                                            "type": "string",
+                                            "description": "Unique identifier for this particular occurrence of the problem.",
+                                            "example": "ac5ah5i"
+                                        },
+                                        "data": {
+                                            "type": "array",
+                                            "description": "Error data.",
+                                            "items": {
+                                                "required": [
+                                                    "code",
+                                                    "type"
+                                                ],
+                                                "type": "object",
+                                                "properties": {
+                                                    "type": {
+                                                        "type": "string",
+                                                        "description": "Type of the response, always \"error\"",
+                                                        "example": "error"
+                                                    },
+                                                    "title": {
+                                                        "type": "string",
+                                                        "description": "Title of the error",
+                                                        "example": "Parameter not valid."
+                                                    },
+                                                    "code": {
+                                                        "type": "string",
+                                                        "description": "Application-specific error code, expressed as a string value.",
+                                                        "example": "parameter-not-valid",
+                                                        "enum": [
+                                                            "parameter-not-supplied",
+                                                            "parameter-not-valid",
+                                                            "unsupported-accept",
+                                                            "invalid-content",
+                                                            "institution-not-supported",
+                                                            "invalid-credentials"
+                                                        ]
+                                                    },
+                                                    "detail": {
+                                                        "type": "string",
+                                                        "description": "Human-readable explanation specific to this occurrence of the problem.",
+                                                        "example": "ID value is not valid."
+                                                    },
+                                                    "source": {
+                                                        "title": "Source",
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "parameter": {
+                                                                "type": "string",
+                                                                "description": "String indicating which URI query parameter caused the error.",
+                                                                "example": "id"
+                                                            }
+                                                        },
+                                                        "description": "An object containing references to the source of the error.",
+                                                        "x-readme-ref-name": "Source"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "x-readme-ref-name": "BadRequestError"
+                                },
+                                "examples": {
+                                    "Bad Request": {
+                                        "value": {
+                                            "type": "list",
+                                            "correlationId": "ac5ah5i",
+                                            "data": [
+                                                {
+                                                    "type": "error",
+                                                    "title": "Parameter not valid.",
+                                                    "code": "parameter-not-valid",
+                                                    "detail": "ID value is not valid.",
+                                                    "source": {
+                                                        "parameter": "id"
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "Invalid Filters": {
+                                        "value": {
+                                            "type": "list",
+                                            "correlationId": "ac5ah55",
+                                            "data": [
+                                                {
+                                                    "type": "error",
+                                                    "code": "parameter-not-valid",
+                                                    "title": "Parameter value is not valid",
+                                                    "detail": "The provided filter parameter is in invalid format or unsupported",
+                                                    "source": {
+                                                        "parameter": "filter"
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Error that access is forbidden and tied to the application logic, such as insufficient rights to a resource.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "required": [
+                                        "correlationId",
+                                        "data",
+                                        "type"
+                                    ],
+                                    "type": "object",
+                                    "properties": {
+                                        "type": {
+                                            "type": "string",
+                                            "description": "Always \"list\".",
+                                            "example": "list"
+                                        },
+                                        "correlationId": {
+                                            "type": "string",
+                                            "description": "Unique identifier for this particular occurrence of the problem.",
+                                            "example": "ac5ah5i"
+                                        },
+                                        "data": {
+                                            "type": "array",
+                                            "description": "Error data.",
+                                            "items": {
+                                                "required": [
+                                                    "code",
+                                                    "source",
+                                                    "type"
+                                                ],
+                                                "type": "object",
+                                                "properties": {
+                                                    "type": {
+                                                        "type": "string",
+                                                        "description": "Type of the response, always \"error\"",
+                                                        "example": "error"
+                                                    },
+                                                    "title": {
+                                                        "type": "string",
+                                                        "description": "Title of the error",
+                                                        "example": "Forbidden Access"
+                                                    },
+                                                    "code": {
+                                                        "type": "string",
+                                                        "description": "Application-specific error code, expressed as a string value.",
+                                                        "example": "forbidden-access",
+                                                        "enum": [
+                                                            "forbidden-access",
+                                                            "no-production-access",
+                                                            "access-denied"
+                                                        ]
+                                                    },
+                                                    "detail": {
+                                                        "type": "string",
+                                                        "description": "Human-readable explanation specific to this occurrence of the problem.",
+                                                        "example": "Access to this resource is forbidden."
+                                                    },
+                                                    "source": {
+                                                        "title": "Source",
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "parameter": {
+                                                                "type": "string",
+                                                                "description": "String indicating which URI query parameter caused the error.",
+                                                                "example": "id"
+                                                            }
+                                                        },
+                                                        "description": "An object containing references to the source of the error.",
+                                                        "x-readme-ref-name": "Source"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "x-readme-ref-name": "ForbiddenAccessError"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Returns error response code indicates that the server encountered an unexpected condition that prevented it from fulfilling the request.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "required": [
+                                        "correlationId",
+                                        "data",
+                                        "type"
+                                    ],
+                                    "type": "object",
+                                    "properties": {
+                                        "type": {
+                                            "type": "string",
+                                            "description": "Always \"list\".",
+                                            "example": "list"
+                                        },
+                                        "correlationId": {
+                                            "type": "string",
+                                            "description": "Unique identifier for this particular occurrence of the problem.",
+                                            "example": "ac5ah5i"
+                                        },
+                                        "data": {
+                                            "type": "array",
+                                            "description": "Error data.",
+                                            "items": {
+                                                "required": [
+                                                    "code",
+                                                    "type"
+                                                ],
+                                                "type": "object",
+                                                "properties": {
+                                                    "code": {
+                                                        "type": "string",
+                                                        "description": "Application-specific error code, expressed as a string value.",
+                                                        "example": "internal-server-error",
+                                                        "enum": [
+                                                            "internal-server-error"
+                                                        ]
+                                                    },
+                                                    "detail": {
+                                                        "type": "string",
+                                                        "description": "Human-readable explanation specific to this occurrence of the problem.",
+                                                        "example": "Internal Server error. Contact support."
+                                                    },
+                                                    "title": {
+                                                        "type": "string",
+                                                        "description": "Title of the error",
+                                                        "example": "Internal Server error."
+                                                    },
+                                                    "type": {
+                                                        "type": "string",
+                                                        "description": "Type of the response, always \"error\"",
+                                                        "example": "error"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "x-readme-ref-name": "InternalServerError"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "services_token": []
+                    }
+                ]
+            }
+        },
+        "/merchants": {
+            "get": {
+                "tags": [
+                    "Enrich"
+                ],
+                "summary": "Search Merchants",
+                "operationId": "MerchantSearch",
+                "description": "Retrieves merchant details. At least one of `abn` or `merchantName` is required for a successful search. Optional filters for suburb and entity type can also be applied.",
+                "parameters": [
+                    {
+                        "name": "abn",
+                        "in": "query",
+                        "description": "The Australian Business Number (ABN) of the merchant. Required if `merchantName` is not provided.",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": false,
+                        "example": "38865358328"
+                    },
+                    {
+                        "name": "merchantName",
+                        "in": "query",
+                        "description": "The name of the merchant. Required if `abn` is not provided.",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": false,
+                        "example": "coles"
+                    },
+                    {
+                        "name": "suburb",
+                        "in": "query",
+                        "description": "The suburb of the merchant location to filter by.",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": false,
+                        "example": "Ryde"
+                    },
+                    {
+                        "name": "entityType",
+                        "in": "query",
+                        "description": "The type of the merchant entity to filter by.",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": false,
+                        "example": "Individual/Sole Trader"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response with merchant data.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "type",
+                                        "size",
+                                        "data",
+                                        "links"
+                                    ],
+                                    "properties": {
+                                        "type": {
+                                            "type": "string",
+                                            "description": "Always 'list'.",
+                                            "example": "list"
+                                        },
+                                        "size": {
+                                            "type": "integer",
+                                            "description": "The number of merchants returned.",
+                                            "example": 1
+                                        },
+                                        "data": {
+                                            "type": "array",
+                                            "description": "Array of merchant objects.",
+                                            "items": {
+                                                "$ref": "#/components/schemas/MerchantDetails"
+                                            }
+                                        },
+                                        "links": {
+                                            "type": "object",
+                                            "properties": {
+                                                "self": {
+                                                    "type": "string",
+                                                    "description": "A link to the current query.",
+                                                    "example": "https://au-api.basiq.io/merchants?abn=38865358328&merchantName=coles&suburb=Ryde&entityType=Individual%2FSole%20Trader"
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "examples": {
+                                    "Successful Response with Data": {
+                                        "value": {
+                                            "type": "list",
+                                            "size": 1,
+                                            "data": [
+                                                {
+                                                    "merchantName": "Coles",
+                                                    "merchantId": "c1ef352e-c807-4bdc-9a70-887f7cc17426",
+                                                    "matchScore": 1,
+                                                    "suburb": null,
+                                                    "state": "NSW",
+                                                    "country": "Australia",
+                                                    "abn": "38865358328",
+                                                    "entityType": "Individual/Sole Trader"
+                                                }
+                                            ],
+                                            "links": {
+                                                "self": "https://au-api.basiq.io/merchants?abn=38865358328&merchantName=coles&suburb=Ryde&entityType=Individual%2FSole%20Trader"
+                                            }
+                                        }
+                                    },
+                                    "No Results Found": {
+                                        "value": {
+                                            "type": "list",
+                                            "size": 0,
+                                            "data": [],
+                                            "links": {
+                                                "self": "https://au-api.basiq.io/merchants?abn=38865358328&entityType=Individual%2FSole+Trader&merchantName=coles&suburb=Ryde"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "services_token": []
+                    }
+                ]
+            }
+        },
+        "/merchants/{merchantId}": {
+            "get": {
+                "tags": [
+                    "Enrich"
+                ],
+                "summary": "Retrieve a merchant",
+                "operationId": "GetMerchantById",
+                "description": "Retrieves a single merchant's details using its unique ID.",
+                "parameters": [
+                    {
+                        "name": "merchantId",
+                        "in": "path",
+                        "description": "The unique identifier of the merchant.",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "required": true,
+                        "example": "c1ef352e-c807-4bdc-9a70-887f7cc17426"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response with a single merchant's detailed data.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SingleMerchantResponse"
+                                },
+                                "example": {
+                                    "source": "enrich",
+                                    "merchant": {
+                                        "id": "c1ef352e-c807-4bdc-9a70-887f7cc17426",
+                                        "businessName": "Coles",
+                                        "website": "",
+                                        "abn": "38865358328",
+                                        "phoneNumber": {
+                                            "local": "",
+                                            "international": ""
+                                        }
+                                    },
+                                    "category": {
+                                        "matchType": "merchantFull",
+                                        "matchScore": 1,
+                                        "anzsic": {
+                                            "division": {
+                                                "code": "0",
+                                                "title": "Unknown"
+                                            },
+                                            "subdivision": {
+                                                "code": "0",
+                                                "title": "Unknown"
+                                            },
+                                            "group": {
+                                                "code": "0",
+                                                "title": "Unknown"
+                                            },
+                                            "class": {
+                                                "code": "0",
+                                                "title": "Unknown"
+                                            },
+                                            "subclass": {
+                                                "code": "0",
+                                                "title": "Unknown"
+                                            }
+                                        }
+                                    },
+                                    "location": {
+                                        "routeNo": "",
+                                        "route": "",
+                                        "postalCode": "2257",
+                                        "suburb": "",
+                                        "state": "NSW",
+                                        "country": "Australia",
+                                        "formattedAddress": "",
+                                        "geometry": {
+                                            "lat": "",
+                                            "lng": ""
+                                        }
+                                    },
+                                    "links": {
+                                        "self": "https://au-api.basiq.io/merchants/c1ef352e-c807-4bdc-9a70-887f7cc17426",
+                                        "logo-master": null,
+                                        "logo-thumb": null
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Merchant not found.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MerchantNotFoundError"
+                                },
+                                "example": {
+                                    "type": "list",
+                                    "correlationId": "85a07b07-46a9-4805-8bab-67f5f1c421e8",
+                                    "data": [
+                                        {
+                                            "type": "error",
+                                            "code": "resource-not-found",
+                                            "title": "Requested resource is not found",
+                                            "detail": "Merchant not found"
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "services_token": []
+                    }
+                ]
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "MerchantDetails": {
+                "type": "object",
+                "properties": {
+                    "merchantName": {
+                        "type": "string",
+                        "description": "The name of the merchant.",
+                        "example": "Coles"
+                    },
+                    "merchantId": {
+                        "type": "string",
+                        "description": "Unique identifier for the merchant.",
+                        "example": "c1ef352e-c807-4bdc-9a70-887f7cc17426"
+                    },
+                    "matchScore": {
+                        "type": "number",
+                        "format": "float",
+                        "description": "Confidence score of the match.",
+                        "example": 1
+                    },
+                    "suburb": {
+                        "type": "string",
+                        "nullable": true,
+                        "description": "The suburb of the merchant location, or null if not available.",
+                        "example": null
+                    },
+                    "state": {
+                        "type": "string",
+                        "description": "The state of the merchant location.",
+                        "example": "NSW"
+                    },
+                    "country": {
+                        "type": "string",
+                        "description": "The country of the merchant location.",
+                        "example": "Australia"
+                    },
+                    "abn": {
+                        "type": "string",
+                        "description": "The Australian Business Number (ABN) of the merchant.",
+                        "example": "38865358328"
+                    },
+                    "entityType": {
+                        "type": "string",
+                        "description": "The type of the merchant entity.",
+                        "example": "Individual/Sole Trader"
+                    }
+                }
+            },
+            "SingleMerchantResponse": {
+                "type": "object",
+                "properties": {
+                    "source": {
+                        "type": "string",
+                        "example": "enrich"
+                    },
+                    "merchant": {
+                        "type": "object",
+                        "properties": {
+                            "id": {
+                                "type": "string",
+                                "description": "The merchant id."
+                            },
+                            "businessName": {
+                                "type": "string",
+                                "description": "The merchant business name."
+                            },
+                            "website": {
+                                "type": "string",
+                                "description": "The merchant website."
+                            },
+                            "abn": {
+                                "type": "string",
+                                "description": "Provides the Australian Business Number."
+                            },
+                            "phoneNumber": {
+                                "type": "object",
+                                "description": "Provides the local and international telephone numbers of the merchant.",
+                                "properties": {
+                                    "local": {
+                                        "type": "string"
+                                    },
+                                    "international": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "category": {
+                        "type": "object",
+                        "properties": {
+                            "matchType": {
+                                "type": "string",
+                                "description": "Indicates the method used to match a payment transaction with a merchant or business classification code.",
+                                "enum": [
+                                    "merchantFull",
+                                    "merchantPartial",
+                                    "mcc",
+                                    "ml"
+                                ]
+                            },
+                            "matchScore": {
+                                "type": "number",
+                                "format": "float",
+                                "description": "The confidence score for the matchType which is a float value between 0 and 1."
+                            },
+                            "anzsic": {
+                                "type": "object",
+                                "properties": {
+                                    "division": {
+                                        "type": "object",
+                                        "properties": {
+                                            "code": {
+                                                "type": "string"
+                                            },
+                                            "title": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    },
+                                    "subdivision": {
+                                        "type": "object",
+                                        "properties": {
+                                            "code": {
+                                                "type": "string"
+                                            },
+                                            "title": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    },
+                                    "group": {
+                                        "type": "object",
+                                        "properties": {
+                                            "code": {
+                                                "type": "string"
+                                            },
+                                            "title": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    },
+                                    "class": {
+                                        "type": "object",
+                                        "properties": {
+                                            "code": {
+                                                "type": "string"
+                                            },
+                                            "title": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    },
+                                    "subclass": {
+                                        "type": "object",
+                                        "properties": {
+                                            "code": {
+                                                "type": "string"
+                                            },
+                                            "title": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "location": {
+                        "type": "object",
+                        "properties": {
+                            "routeNo": {
+                                "type": "string"
+                            },
+                            "route": {
+                                "type": "string"
+                            },
+                            "postalCode": {
+                                "type": "string"
+                            },
+                            "suburb": {
+                                "type": "string"
+                            },
+                            "state": {
+                                "type": "string"
+                            },
+                            "country": {
+                                "type": "string"
+                            },
+                            "formattedAddress": {
+                                "type": "string"
+                            },
+                            "geometry": {
+                                "type": "object",
+                                "properties": {
+                                    "lat": {
+                                        "type": "string"
+                                    },
+                                    "lng": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "links": {
+                        "type": "object",
+                        "properties": {
+                            "self": {
+                                "type": "string",
+                                "description": "Provides a reference link to the original query."
+                            },
+                            "logo-master": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "Provides link to master logo. Where null no merchant logo is available."
+                            },
+                            "logo-thumb": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "Provides link to thumb logo. Where null no merchant logo is available."
+                            }
+                        }
+                    }
+                }
+            },
+            "MerchantNotFoundError": {
+                "type": "object",
+                "required": [
+                    "correlationId",
+                    "data",
+                    "type"
+                ],
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "description": "Always \"list\".",
+                        "example": "list"
+                    },
+                    "correlationId": {
+                        "type": "string",
+                        "description": "Unique identifier for this particular occurrence of the problem.",
+                        "example": "85a07b07-46a9-4805-8bab-67f5f1c421e8"
+                    },
+                    "data": {
+                        "type": "array",
+                        "description": "Error data.",
+                        "items": {
+                            "type": "object",
+                            "required": [
+                                "code",
+                                "type"
+                            ],
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "description": "Type of the response, always \"error\"",
+                                    "example": "error"
+                                },
+                                "title": {
+                                    "type": "string",
+                                    "description": "Title of the error",
+                                    "example": "Requested resource is not found"
+                                },
+                                "code": {
+                                    "type": "string",
+                                    "description": "Application-specific error code, expressed as a string value.",
+                                    "example": "resource-not-found",
+                                    "enum": [
+                                        "resource-not-found"
+                                    ]
+                                },
+                                "detail": {
+                                    "type": "string",
+                                    "description": "Human-readable explanation specific to this occurrence of the problem.",
+                                    "example": "Merchant not found"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "securitySchemes": {
+            "services_token": {
+                "type": "http",
+                "scheme": "bearer",
+                "bearerFormat": "JWT"
+            }
+        }
+    },
+    "security": [
+        {
+            "services_token": []
+        }
+    ],
+    "x-readme": {
+        "explorer-enabled": true,
+        "proxy-enabled": true,
+        "samples-enabled": true,
+        "samples-languages": [
+            "curl",
+            "node",
+            "ruby",
+            "javascript",
+            "python"
+        ]
+    }
+}


### PR DESCRIPTION
Description:
This PR updates the `tags` field in the OpenAPI specification for transactions.

Changes include:
1. Added new `governmentPayment` tags:
   - familyTaxBenefit
   - stillbornPymt
   - childCareSubsidy
   - parentalLeavePymt
   - parentingPymt
   - disabilitySupport
   - pensionerEducationSupplement
   - farmAllowance
   - disasterPymt

2. Improved tagging coverage for existing `governmentPayment` tags:
   - familyAllowance
   - jobseekerPymt
   - education
   - youthAllowance
