### PR TITLE
DX-996 Align API filters with Backend Validation

### DIFF
--- a/reference/data.json
+++ b/reference/data.json
@@ -35,7 +35,7 @@
           {
             "name": "filter",
             "in": "query",
-            "description": "Account filters; account.id, connection.id, institution.id, Only equals (eq) operation is currently supported.",
+            "description": "Account filters: account.id, connection.id, institution.id. Only the equals (eq) operation is currently supported.",
             "schema": {
               "type": "string"
             }

--- a/reference/data.json
+++ b/reference/data.json
@@ -35,7 +35,7 @@
           {
             "name": "filter",
             "in": "query",
-            "description": "Account filters; account.id, connection.id, institution.id, Only equals (eq) and not equals (ne) operations are currently supported.",
+            "description": "Account filters; account.id, connection.id, institution.id, Only equals (eq) operation is currently supported.",
             "schema": {
               "type": "string"
             }
@@ -1524,7 +1524,7 @@
           {
             "name": "filter",
             "in": "query",
-            "description": "Account filters; account.id, connection.id, institution.id, Only equals (eq) and not equals (ne) operations are currently supported.",
+            "description": "Account filters; account.id, connection.id, institution.id, Only equals (eq) operation is currently supported.",
             "schema": {
               "type": "string"
             }
@@ -2911,7 +2911,7 @@
           {
             "name": "filter",
             "in": "query",
-            "description": "Transaction filters; account.id, transaction.postDate, transaction.status, institution.id, transaction.direction, transaction.class",
+            "description": "Transaction filters; connection.id, account.id, transaction.postDate, transaction.status, institution.id, transaction.direction, transaction.class",
             "schema": {
               "type": "string"
             }

--- a/reference/payees.json
+++ b/reference/payees.json
@@ -51,7 +51,7 @@
           {
             "name": "filter",
             "in": "query",
-            "description": "Filter expression to narrow down results. Supports the following filters:\n- `type.eq('value')` - Filter by payee type (domestic, biller, international, digitalWallet)\n- `connectionId.eq('value')` - Filter by connection ID\n- `created.bt('startDate','endDate')` - Filter by creation date range\n- `created.gt('date')` - Filter by creation date greater than\n- `created.gteq('date')` - Filter by creation date greater than or equal\n- `created.lt('date')` - Filter by creation date less than",
+            "description": "Filter expression to narrow down results. Supports the following filters:\n- `type.eq('value')` - Filter by payee type (domestic, biller, international, digitalWallet)\n- `connectionId.eq('value')` - Filter by connection ID\n- `created.bt('startDate','endDate')` - Filter by creation date range\n- `created.gt('date')` - Filter by creation date greater than\n- `created.gteq('date')` - Filter by creation date greater than or equal\n- `created.lt('date')` - Filter by creation date less than\n- `created.lteq('date')` - Filter by creation date less than or equal\n- `created.eq('date')` - Filter by creation date equal to",   
             "schema": {
               "type": "string"
             },


### PR DESCRIPTION
### Changes
- Updated filter description in OpenAPI spec to remove mention of `ne` operation
- Clarified that only `eq` (equals) is currently supported
- Removed misleading reference to not-equals functionality