### PR TITLE
DX-1020  fix(spec): correct required fields, enum placement, narrow enum

### DIFF
--- a/docs/Getting Started/getting-started/quickstart-api.md
+++ b/docs/Getting Started/getting-started/quickstart-api.md
@@ -42,6 +42,10 @@ Exchange your newly acquired API key for an access token. This token enables sec
 >
 > The scope you supply will depend on the action you are performing, see the [authentication section](https://api.basiq.io/reference/authentication) for further detail. For this quick start we will be using `SERVER_ACCESS`.
 
+> 🚧 API key format — do not Base64-encode
+>
+> The API key is passed **verbatim** as the Basic auth value. Unlike standard HTTP Basic Auth, there is no `base64(username:password)` encoding step — use the key exactly as issued from the dashboard. Encoding the key will result in a `400` error.
+
 ```javascript STEP 2: Authenticate
 var axios = require('axios');
 var qs = require('qs');

--- a/reference/Core/authentication/posttoken.md
+++ b/reference/Core/authentication/posttoken.md
@@ -9,3 +9,13 @@ hidden: false
 
   The response will contain an access token which will allow you to make secure calls to the Basiq API. They expire every 60 minutes, so we recommend you store it globally and refresh 2-3 times an hour.
 </Callout>
+
+<Callout icon="🚧" theme="warn">
+  **API key format — do not Base64-encode**
+
+  Unlike standard HTTP Basic Auth, the Basiq API key is passed **verbatim** as the header value. The correct header is:
+
+  `Authorization: Basic <your-api-key-as-issued>`
+
+  Base64-encoding the key (as the HTTP spec normally requires for `user:password` credentials) will produce a `400` error. Use the key exactly as issued from the dashboard.
+</Callout>

--- a/reference/core.json
+++ b/reference/core.json
@@ -5407,25 +5407,13 @@
                           },
                           "entity": {
                             "type": "string",
-                            "description": "The entity associated with the event that has occurred",
-                            "example": "consent",
-                            "enum": [
-                              "consent",
-                              "connection"
-                            ]
+                            "description": "The entity associated with the event that has occurred. Known values include consent, connection, account, transaction, and user. This list is not exhaustive.",
+                            "example": "consent"
                           },
                           "eventType": {
                             "type": "string",
-                            "description": "The type of event that has occurred",
-                            "example": "revoked",
-                            "enum": [
-                              "revoked",
-                              "expired",
-                              "updated",
-                              "created",
-                              "archived",
-                              "deleted"
-                            ]
+                            "description": "The type of event that has occurred. Known values include revoked, expired, updated, created, archived, and deleted. This list is not exhaustive.",
+                            "example": "revoked"
                           },
                           "userId": {
                             "type": "string",
@@ -7773,14 +7761,8 @@
                               "properties": {
                                 "title": {
                                   "type": "string",
-                                  "description": "Name of the step the job needs to complete.",
-                                  "example": "retrieve-accounts",
-                                  "enum": [
-                                    "verify-credentials",
-                                    "retrieve-accounts",
-                                    "retrieve-transactions",
-                                    "retrieve-statements"
-                                  ]
+                                  "description": "Name of the step the job needs to complete. Known values include verify-credentials, retrieve-accounts, retrieve-transactions, and retrieve-statements. Additional step types may be returned for report and affordability jobs. This list is not exhaustive.",
+                                  "example": "retrieve-accounts"
                                 },
                                 "status": {
                                   "type": "string",

--- a/reference/data.json
+++ b/reference/data.json
@@ -72,12 +72,8 @@
                           "name",
                           "displayName",
                           "accountNo",
-                          "accountHolder",
                           "isOwned",
                           "accountOwnership",
-                          "balance",
-                          "availableFunds",
-                          "creditLimit",
                           "currency",
                           "class",
                           "connection",
@@ -1545,12 +1541,8 @@
                     "status",
                     "name",
                     "accountNo",
-                    "accountHolder",
                     "isOwned",
                     "accountOwnership",
-                    "balance",
-                    "availableFunds",
-                    "creditLimit",
                     "currency",
                     "class",
                     "connection",
@@ -2960,7 +2952,6 @@
                           "amount",
                           "currency",
                           "class",
-                          "subClass",
                           "connection",
                           "direction",
                           "enrich",
@@ -3021,7 +3012,8 @@
                           "balance": {
                             "type": "string",
                             "description": "Account balance at the time the transaction was completed. Included for Web connection integrations. CDR does not supply transaction balance, so this field will be empty for CDR connections.",
-                            "example": "123.12"
+                            "example": "123.12",
+                            "nullable": true
                           },
                           "direction": {
                             "type": "string",
@@ -3827,7 +3819,6 @@
                     "amount",
                     "currency",
                     "class",
-                    "subClass",
                     "connection",
                     "direction",
                     "enrich",
@@ -3888,7 +3879,8 @@
                     "balance": {
                       "type": "string",
                       "description": "Account balance at the time the transaction was completed. Included for Web connection integrations. CDR does not supply transaction balance, so this field will be empty for CDR connections.",
-                      "example": "123.12"
+                      "example": "123.12",
+                      "nullable": true
                     },
                     "direction": {
                       "type": "string",
@@ -5746,8 +5738,6 @@
                               "id",
                               "lastUpdated",
                               "accountNo",
-                              "availableFunds",
-                              "balance",
                               "class",
                               "currency",
                               "links",
@@ -8248,9 +8238,7 @@
                           "institution",
                           "method",
                           "stage",
-                          "stats",
                           "status",
-                          "scopes",
                           "authorization"
                         ],
                         "type": "object",
@@ -8915,9 +8903,7 @@
                     "institution",
                     "method",
                     "stage",
-                    "stats",
                     "status",
-                    "scopes",
                     "authorization"
                   ],
                   "type": "object",
@@ -9899,8 +9885,6 @@
                 "id",
                 "lastUpdated",
                 "accountNo",
-                "availableFunds",
-                "balance",
                 "class",
                 "currency",
                 "links",
@@ -10012,8 +9996,6 @@
           "id",
           "lastUpdated",
           "accountNo",
-          "availableFunds",
-          "balance",
           "class",
           "currency",
           "links",
@@ -10316,9 +10298,7 @@
                 "institution",
                 "method",
                 "stage",
-                "stats",
                 "status",
-                "scopes",
                 "authorization"
               ],
               "type": "object",
@@ -10653,9 +10633,7 @@
           "institution",
           "method",
           "stage",
-          "stats",
           "status",
-          "scopes",
           "authorization"
         ],
         "type": "object",
@@ -11454,8 +11432,6 @@
                     "id",
                     "lastUpdated",
                     "accountNo",
-                    "availableFunds",
-                    "balance",
                     "class",
                     "currency",
                     "links",
@@ -12044,12 +12020,8 @@
           "status",
           "name",
           "accountNo",
-          "accountHolder",
           "isOwned",
           "accountOwnership",
-          "balance",
-          "availableFunds",
-          "creditLimit",
           "currency",
           "class",
           "connection",
@@ -12168,18 +12140,6 @@
           },
           "class": {
             "description": "Describes the class(type) of accounts.",
-            "enum": [
-              "transaction",
-              "savings",
-              "credit-card",
-              "mortgage",
-              "loan",
-              "investment",
-              "term-deposit",
-              "insurance",
-              "foreign",
-              "unknown"
-            ],
             "required": [
               "type",
               "product"
@@ -12188,7 +12148,19 @@
               "type": {
                 "type": "string",
                 "description": "Account type",
-                "example": "mortgage"
+                "example": "mortgage",
+                "enum": [
+                  "transaction",
+                  "savings",
+                  "credit-card",
+                  "mortgage",
+                  "loan",
+                  "investment",
+                  "term-deposit",
+                  "insurance",
+                  "foreign",
+                  "unknown"
+                ]
               },
               "product": {
                 "type": "string",
@@ -12196,7 +12168,8 @@
                 "example": "Hooli Home Loan"
               }
             },
-            "x-readme-ref-name": "AccountClass"
+            "x-readme-ref-name": "AccountClass",
+            "type": "object"
           },
           "connection": {
             "type": "string",
@@ -14564,12 +14537,8 @@
                 "status",
                 "name",
                 "accountNo",
-                "accountHolder",
                 "isOwned",
                 "accountOwnership",
-                "balance",
-                "availableFunds",
-                "creditLimit",
                 "currency",
                 "class",
                 "connection",
@@ -14688,18 +14657,6 @@
                 },
                 "class": {
                   "description": "Describes the class(type) of accounts.",
-                  "enum": [
-                    "transaction",
-                    "savings",
-                    "credit-card",
-                    "mortgage",
-                    "loan",
-                    "investment",
-                    "term-deposit",
-                    "insurance",
-                    "foreign",
-                    "unknown"
-                  ],
                   "required": [
                     "type",
                     "product"
@@ -14708,7 +14665,19 @@
                     "type": {
                       "type": "string",
                       "description": "Account type",
-                      "example": "mortgage"
+                      "example": "mortgage",
+                      "enum": [
+                        "transaction",
+                        "savings",
+                        "credit-card",
+                        "mortgage",
+                        "loan",
+                        "investment",
+                        "term-deposit",
+                        "insurance",
+                        "foreign",
+                        "unknown"
+                      ]
                     },
                     "product": {
                       "type": "string",
@@ -14716,7 +14685,8 @@
                       "example": "Hooli Home Loan"
                     }
                   },
-                  "x-readme-ref-name": "AccountClass"
+                  "x-readme-ref-name": "AccountClass",
+                  "type": "object"
                 },
                 "connection": {
                   "type": "string",
@@ -16077,7 +16047,6 @@
           "amount",
           "currency",
           "class",
-          "subClass",
           "connection",
           "direction",
           "enrich",
@@ -16138,7 +16107,8 @@
           "balance": {
             "type": "string",
             "description": "Account balance at the time the transaction was completed. Included for Web connection integrations. CDR does not supply transaction balance, so this field will be empty for CDR connections.",
-            "example": "123.12"
+            "example": "123.12",
+            "nullable": true
           },
           "direction": {
             "type": "string",
@@ -17162,7 +17132,6 @@
                 "amount",
                 "currency",
                 "class",
-                "subClass",
                 "connection",
                 "direction",
                 "enrich",
@@ -17223,7 +17192,8 @@
                 "balance": {
                   "type": "string",
                   "description": "Account balance at the time the transaction was completed. Included for Web connection integrations. CDR does not supply transaction balance, so this field will be empty for CDR connections.",
-                  "example": "123.12"
+                  "example": "123.12",
+                  "nullable": true
                 },
                 "direction": {
                   "type": "string",


### PR DESCRIPTION
…ums, auth docs clarity

- Remove stats and scopes from Connector required (4 occurrences) — live API returns null
- Remove accountHolder, balance, availableFunds, creditLimit from AccountResponseResource required (4 occurrences) — CDR connections omit these
- Remove availableFunds and balance from AccountsData required (4 occurrences)
- Remove subClass from TransactionData required (4 occurrences) — absent on non-payment transactions
- Add nullable: true to TransactionData.balance (4 occurrences) — CDR connections omit it
- Move AccountResponseResource.class enum from object level to properties.type.enum (2 occurrences) — enum on object schema is meaningless in JSON Schema
- Remove narrow enum from JobsData.steps[].title; update description to document known values and note list is not exhaustive
- Remove narrow enum from EventsData.entity and EventsData.eventType; update descriptions to document known values
- Add warning callout to posttoken.md and quickstart-api.md clarifying API key is passed verbatim — do not Base64-encode