### PR TITLE
DX-926 fix(connect): correct schema issues in fees, lending rates, and transactions

### DIFF
--- a/reference/connect.json
+++ b/reference/connect.json
@@ -9546,44 +9546,47 @@
                                             "description": "Link to a web page with more information on this discount."
                                           },
                                           "eligibility": {
+                                            "type": "array",
                                             "description": "Eligibility constraints that apply to this discount. Mandatory if discountType is ELIGIBILITY_ONLY.",
-                                            "required": [
-                                              "discountEligibilityType"
-                                            ],
-                                            "properties": {
-                                              "discountEligibilityType": {
-                                                "type": "string",
-                                                "description": "The type of the specific eligibility constraint for a discountType.",
-                                                "enum": [
-                                                  "BUSINESS",
-                                                  "EMPLOYMENT_STATUS",
-                                                  "INTRODUCTORY",
-                                                  "MAX_AGE",
-                                                  "MIN_AGE",
-                                                  "MIN_INCOME",
-                                                  "MIN_TURNOVER",
-                                                  "NATURAL_PERSON",
-                                                  "OTHER",
-                                                  "PENSION_RECIPIENT",
-                                                  "RESIDENCY_STATUS",
-                                                  "STAFF",
-                                                  "STUDENT"
-                                                ]
+                                            "items": {
+                                              "required": [
+                                                "discountEligibilityType"
+                                              ],
+                                              "properties": {
+                                                "discountEligibilityType": {
+                                                  "type": "string",
+                                                  "description": "The type of the specific eligibility constraint for a discountType.",
+                                                  "enum": [
+                                                    "BUSINESS",
+                                                    "EMPLOYMENT_STATUS",
+                                                    "INTRODUCTORY",
+                                                    "MAX_AGE",
+                                                    "MIN_AGE",
+                                                    "MIN_INCOME",
+                                                    "MIN_TURNOVER",
+                                                    "NATURAL_PERSON",
+                                                    "OTHER",
+                                                    "PENSION_RECIPIENT",
+                                                    "RESIDENCY_STATUS",
+                                                    "STAFF",
+                                                    "STUDENT"
+                                                  ]
+                                                },
+                                                "additionalValue": {
+                                                  "type": "string",
+                                                  "description": "Generic field containing additional information relevant to the discountEligibilityType specified. Whether mandatory or not is dependent on the value of discountEligibilityType."
+                                                },
+                                                "additionalInfo": {
+                                                  "type": "string",
+                                                  "description": "Display text providing more information on this eligibility constraint. Whether mandatory or not is dependent on the value of discountEligibilityType."
+                                                },
+                                                "additionalInfoUri": {
+                                                  "type": "string",
+                                                  "description": "Link to a web page with more information on this eligibility constraint."
+                                                }
                                               },
-                                              "additionalValue": {
-                                                "type": "string",
-                                                "description": "Generic field containing additional information relevant to the discountEligibilityType specified. Whether mandatory or not is dependent on the value of discountEligibilityType."
-                                              },
-                                              "additionalInfo": {
-                                                "type": "string",
-                                                "description": "Display text providing more information on this eligibility constraint. Whether mandatory or not is dependent on the value of discountEligibilityType."
-                                              },
-                                              "additionalInfoUri": {
-                                                "type": "string",
-                                                "description": "Link to a web page with more information on this eligibility constraint."
-                                              }
-                                            },
-                                            "x-readme-ref-name": "feesdiscounteligibilityMetadata"
+                                              "x-readme-ref-name": "feesdiscounteligibilityMetadata"
+                                            }
                                           }
                                         },
                                         "x-readme-ref-name": "feesdiscountMetadata"
@@ -9672,6 +9675,7 @@
                                             ]
                                           },
                                           "applicabilityConditions": {
+                                            "nullable": true,
                                             "properties": {
                                               "additionalInfo": {
                                                 "type": "string",
@@ -9825,6 +9829,7 @@
                                             ]
                                           },
                                           "applicabilityConditions": {
+                                            "nullable": true,
                                             "properties": {
                                               "additionalInfo": {
                                                 "type": "string",
@@ -11007,44 +11012,47 @@
                                       "description": "Link to a web page with more information on this discount."
                                     },
                                     "eligibility": {
+                                      "type": "array",
                                       "description": "Eligibility constraints that apply to this discount. Mandatory if discountType is ELIGIBILITY_ONLY.",
-                                      "required": [
-                                        "discountEligibilityType"
-                                      ],
-                                      "properties": {
-                                        "discountEligibilityType": {
-                                          "type": "string",
-                                          "description": "The type of the specific eligibility constraint for a discountType.",
-                                          "enum": [
-                                            "BUSINESS",
-                                            "EMPLOYMENT_STATUS",
-                                            "INTRODUCTORY",
-                                            "MAX_AGE",
-                                            "MIN_AGE",
-                                            "MIN_INCOME",
-                                            "MIN_TURNOVER",
-                                            "NATURAL_PERSON",
-                                            "OTHER",
-                                            "PENSION_RECIPIENT",
-                                            "RESIDENCY_STATUS",
-                                            "STAFF",
-                                            "STUDENT"
-                                          ]
+                                      "items": {
+                                        "required": [
+                                          "discountEligibilityType"
+                                        ],
+                                        "properties": {
+                                          "discountEligibilityType": {
+                                            "type": "string",
+                                            "description": "The type of the specific eligibility constraint for a discountType.",
+                                            "enum": [
+                                              "BUSINESS",
+                                              "EMPLOYMENT_STATUS",
+                                              "INTRODUCTORY",
+                                              "MAX_AGE",
+                                              "MIN_AGE",
+                                              "MIN_INCOME",
+                                              "MIN_TURNOVER",
+                                              "NATURAL_PERSON",
+                                              "OTHER",
+                                              "PENSION_RECIPIENT",
+                                              "RESIDENCY_STATUS",
+                                              "STAFF",
+                                              "STUDENT"
+                                            ]
+                                          },
+                                          "additionalValue": {
+                                            "type": "string",
+                                            "description": "Generic field containing additional information relevant to the discountEligibilityType specified. Whether mandatory or not is dependent on the value of discountEligibilityType."
+                                          },
+                                          "additionalInfo": {
+                                            "type": "string",
+                                            "description": "Display text providing more information on this eligibility constraint. Whether mandatory or not is dependent on the value of discountEligibilityType."
+                                          },
+                                          "additionalInfoUri": {
+                                            "type": "string",
+                                            "description": "Link to a web page with more information on this eligibility constraint."
+                                          }
                                         },
-                                        "additionalValue": {
-                                          "type": "string",
-                                          "description": "Generic field containing additional information relevant to the discountEligibilityType specified. Whether mandatory or not is dependent on the value of discountEligibilityType."
-                                        },
-                                        "additionalInfo": {
-                                          "type": "string",
-                                          "description": "Display text providing more information on this eligibility constraint. Whether mandatory or not is dependent on the value of discountEligibilityType."
-                                        },
-                                        "additionalInfoUri": {
-                                          "type": "string",
-                                          "description": "Link to a web page with more information on this eligibility constraint."
-                                        }
-                                      },
-                                      "x-readme-ref-name": "feesdiscounteligibilityMetadata"
+                                        "x-readme-ref-name": "feesdiscounteligibilityMetadata"
+                                      }
                                     }
                                   },
                                   "x-readme-ref-name": "feesdiscountMetadata"
@@ -11133,6 +11141,7 @@
                                       ]
                                     },
                                     "applicabilityConditions": {
+                                      "nullable": true,
                                       "properties": {
                                         "additionalInfo": {
                                           "type": "string",
@@ -11286,6 +11295,7 @@
                                       ]
                                     },
                                     "applicabilityConditions": {
+                                      "nullable": true,
                                       "properties": {
                                         "additionalInfo": {
                                           "type": "string",
@@ -12224,6 +12234,7 @@
                           },
                           "paymentDetails": {
                             "type": "object",
+                            "nullable": true,
                             "properties": {
                               "bpay": {
                                 "type": "object",
@@ -13091,6 +13102,7 @@
                     },
                     "paymentDetails": {
                       "type": "object",
+                      "nullable": true,
                       "properties": {
                         "bpay": {
                           "type": "object",

--- a/reference/connect.json
+++ b/reference/connect.json
@@ -9675,6 +9675,7 @@
                                             ]
                                           },
                                           "applicabilityConditions": {
+                                            "type": "object",
                                             "nullable": true,
                                             "properties": {
                                               "additionalInfo": {
@@ -9829,6 +9830,7 @@
                                             ]
                                           },
                                           "applicabilityConditions": {
+                                            "type": "object",
                                             "nullable": true,
                                             "properties": {
                                               "additionalInfo": {
@@ -11141,6 +11143,7 @@
                                       ]
                                     },
                                     "applicabilityConditions": {
+                                      "type": "object",
                                       "nullable": true,
                                       "properties": {
                                         "additionalInfo": {
@@ -11295,6 +11298,7 @@
                                       ]
                                     },
                                     "applicabilityConditions": {
+                                      "type": "object",
                                       "nullable": true,
                                       "properties": {
                                         "additionalInfo": {


### PR DESCRIPTION
- meta.fees[].discounts[].eligibility: changed from object to array of objects to match actual API data shape
- meta.lendingRates[].tiers[].applicabilityConditions: marked nullable to reflect that the field can be null in API responses (also applies to depositRates tiers)
- transactions.paymentDetails: marked nullable to reflect that the field can be null in API responses